### PR TITLE
Support (de)register instances with target_group

### DIFF
--- a/lib/applb/client_wrapper.rb
+++ b/lib/applb/client_wrapper.rb
@@ -9,7 +9,8 @@ module Applb
       set_ip_address_type modify_load_balancer_attributes create_target_group
       modify_target_group delete_target_group create_listener modify_listener
       delete_listener describe_rules delete_rule create_load_balancer
-      create_rule modify_rule set_rule_priorities describe_target_groups/
+      create_rule modify_rule set_rule_priorities describe_target_groups
+      describe_target_health register_targets deregister_targets/
 
     def initialize(options)
       @includes = options[:includes] || []

--- a/lib/applb/dsl/load_balancer.rb
+++ b/lib/applb/dsl/load_balancer.rb
@@ -11,7 +11,7 @@ module Applb
         include Applb::TemplateHelper
 
         class Result
-          ATTRIBUTES = %i/name instances scheme subnets security_groups tags ip_address_type attributes target_groups listeners load_balancer_arn/
+          ATTRIBUTES = %i/name scheme subnets security_groups tags ip_address_type attributes target_groups listeners load_balancer_arn/
           attr_accessor *ATTRIBUTES
 
           def initialize(context)
@@ -156,7 +156,6 @@ module Applb
           @result = Result.new(@context)
           @result.name = name
           @result.attributes = Attributes.new(@context, @name) {}.result
-          @result.instances = []
           @result.target_groups = []
           @result.listeners = []
 

--- a/lib/applb/dsl/target_group.rb
+++ b/lib/applb/dsl/target_group.rb
@@ -11,7 +11,7 @@ module Applb
               ATTRIBUTES = %i/
                 name protocol port vpc_id health_check_protocol health_check_port health_check_path
                 health_check_interval_seconds health_check_timeout_seconds healthy_threshold_count
-                unhealthy_threshold_count matcher
+                unhealthy_threshold_count matcher instances
               /
 
               attr_accessor *ATTRIBUTES
@@ -27,6 +27,10 @@ module Applb
 
               def aws(aws_tg)
                 @aws_tg = aws_tg
+                @aws_instances = client.
+                  describe_target_health(target_group_arn: @aws_tg.target_group_arn).
+                  target_health_descriptions.reject { |description| description.target_health.state == "draining" }.
+                  map(&:target).map(&:id).sort
                 self
               end
 
@@ -45,19 +49,23 @@ module Applb
                 Applb.logger.info("<diff>\n#{Applb::Utils.diff(aws_hash, dsl_hash, color: @options[:color])}")
                 return if @options[:dry_run]
 
+                modify_instances
                 client.modify_target_group(modify_option).target_groups.first
               end
 
               private
 
               def create_option
-                to_h
+                hash = to_h
+                hash.delete(:instances)
+                hash
               end
 
               UNMODIFIABLE_ATTRIBUTES = %i/name port protocol vpc_id/
               def modify_option
-                options = to_h.
-                  merge(target_group_arn: @aws_tg.target_group_arn).
+                hash = to_h
+                hash.delete(:instances)
+                hash.merge(target_group_arn: @aws_tg.target_group_arn).
                   reject! { |k, v| UNMODIFIABLE_ATTRIBUTES.include?(k) }
               end
 
@@ -70,9 +78,28 @@ module Applb
               def to_diff_h_aws
                 hash = @aws_tg.to_h
                 hash[:name] = hash.delete(:target_group_name)
+                hash[:instances] = @aws_instances
                 hash.delete(:target_group_arn)
                 hash.delete(:load_balancer_arns)
                 Hash[hash.sort]
+              end
+
+              def modify_instances
+                return if instances == @aws_instances
+
+                register_targets = (instances - @aws_instances).map do |instance|
+                  {id: instance}
+                end
+                if !register_targets.empty?
+                  client.register_targets(target_group_arn: @aws_tg.target_group_arn, targets: register_targets)
+                end
+
+                deregister_targets = (@aws_instances - instances).map do |instance|
+                  {id: instance}
+                end
+                if !deregister_targets.empty?
+                  client.deregister_targets(target_group_arn: @aws_tg.target_group_arn, targets: deregister_targets)
+                end
               end
 
               def client
@@ -85,6 +112,7 @@ module Applb
               @lb_name = lb_name
               @result = Result.new(@context)
               @result.name = name
+              @result.instances = []
 
               instance_eval(&block)
             end
@@ -146,6 +174,10 @@ module Applb
 
             def matcher(http_code:)
               @result.matcher = { http_code: http_code }
+            end
+
+            def instances(*instances)
+              @result.instances = instances.sort
             end
           end
         end

--- a/lib/applb/output_alb.erb
+++ b/lib/applb/output_alb.erb
@@ -55,6 +55,11 @@ ec2 <%= vpc_id.inspect %> do
         healthy_threshold_count <%= target_group.healthy_threshold_count %>
         unhealthy_threshold_count <%= target_group.unhealthy_threshold_count %>
         matcher http_code: <%= target_group.matcher.http_code.inspect %>
+        instances(
+        <%- attr[:instances_by_target_group_arn][target_group.target_group_arn].each do |instance| -%>
+          <%= instance.inspect %>,
+        <%- end -%>
+        )
       end
       <%- end -%>
     end

--- a/spec/aws_config.yml.sample
+++ b/spec/aws_config.yml.sample
@@ -9,3 +9,14 @@ vpc_id: vpc-00000000
 default_security_group: sg-00000000
 security_groups:
   - sg-00000001
+instances:
+  -
+    id: i-00000000000000001
+    name: hostname1
+  -
+    id: i-00000000000000002
+    name: hostname2
+another_instances:
+  -
+    id: i-00000000000000003
+    name: hostname3


### PR DESCRIPTION
This patch codenize the specified target instances with the specified target group as below.
```
    target_groups do
      target_group "my-target-group" do
        protocol "HTTP" # HTTP or HTTPS
        port 80
        vpc_id "vpc-XXXXXXXX"
        health_check_interval_seconds 30
        health_check_path "/healthcheck"
        health_check_port "traffic-port" # specify port number or use traffic-port which indicates the port on which each target receives traffic from the load balancer.
        health_check_protocol "HTTP" # HTTP or HTTPS
        health_check_timeout_seconds 5
        healthy_threshold_count 5
        unhealthy_threshold_count 2
        matcher http_code: "200"
        instances(
          "hostname1",
          "hostname2",
        )
      end
    end
```

`instances` receives EC2 Name values or Instance IDs as arguments.
And you can export instances to DSL by Name values.