### PR TITLE
Bugfix: Exclude opt

### DIFF
--- a/lib/applb/cli.rb
+++ b/lib/applb/cli.rb
@@ -45,7 +45,7 @@ module Applb
         opts.on('',   '--split-more', 'split export DSL file to 1 per load balancer') { @options[:split_more] = true }
         opts.on('',   '--no-color', 'no color') { @options[:color] = false }
         opts.on('-i', '--include-names NAMES', 'include ELB v2(ALB) names', Array) { |v| @options[:includes] = v }
-        opts.on('-x', '--exclude-names NAMES', 'exclude ELB v2(ALB) names by regex', Array) do |v|
+        opts.on('-x', '--exclude-names NAMES', 'exclude ELB v2(ALB) names by regex, or comma-separated ELB names', Array) do |v|
           @options[:excludes] = v.map! do |name|
             name =~ /\A\/(.*)\/\z/ ? Regexp.new($1) : Regexp.new("\A#{Regexp.escape(name)}\z")
           end

--- a/lib/applb/cli.rb
+++ b/lib/applb/cli.rb
@@ -47,7 +47,7 @@ module Applb
         opts.on('-i', '--include-names NAMES', 'include ELB v2(ALB) names', Array) { |v| @options[:includes] = v }
         opts.on('-x', '--exclude-names NAMES', 'exclude ELB v2(ALB) names by regex, or comma-separated ELB names', Array) do |v|
           @options[:excludes] = v.map! do |name|
-            name =~ /\A\/(.*)\/\z/ ? Regexp.new($1) : Regexp.new("\A#{Regexp.escape(name)}\z")
+            name =~ %r{\A/(.*)/\z} ? Regexp.new(Regexp.last_match(1)) : Regexp.new("\A#{Regexp.escape(name)}\z")
           end
         end
       end

--- a/lib/applb/cli.rb
+++ b/lib/applb/cli.rb
@@ -47,7 +47,7 @@ module Applb
         opts.on('-i', '--include-names NAMES', 'include ELB v2(ALB) names', Array) { |v| @options[:includes] = v }
         opts.on('-x', '--exclude-names NAMES', 'exclude ELB v2(ALB) names by regex, or comma-separated ELB names', Array) do |v|
           @options[:excludes] = v.map! do |name|
-            name =~ %r{\A/(.*)/\z} ? Regexp.new(Regexp.last_match(1)) : Regexp.new("\A#{Regexp.escape(name)}\z")
+            name =~ %r{\A/(.*)/\z} ? Regexp.new(Regexp.last_match(1)) : /\A#{Regexp.escape(name)}\z/
           end
         end
       end


### PR DESCRIPTION
Found a tiny bug when passed string(s) to `-x`, not surrounded by `/`s.
